### PR TITLE
Update/enhance base Xcode template

### DIFF
--- a/Base.xctemplate/TemplateInfo.plist
+++ b/Base.xctemplate/TemplateInfo.plist
@@ -115,6 +115,18 @@
 		</dict>
 		<dict>
 			<key>Identifier</key>
+			<string>organizationName</string>
+			<key>Name</key>
+			<string>Organization Name</string>
+			<key>Description</key>
+			<string>Your company&apos;s name</string>
+			<key>Type</key>
+			<string>text</string>
+			<key>Default</key>
+			<string>___FULLUSERNAME___</string>
+		</dict>
+		<dict>
+			<key>Identifier</key>
 			<string>bundleIdentifierPrefix</string>
 			<key>Required</key>
 			<true/>

--- a/Base.xctemplate/TemplateInfo.plist
+++ b/Base.xctemplate/TemplateInfo.plist
@@ -66,6 +66,8 @@
 			<string>latest_iphoneos</string>
 			<key>FRAMEWORK_SEARCH_PATHS</key>
 			<string>$(iOSOpenDevPath)/frameworks/** $(SDKROOT)/System/Library/PrivateFrameworks</string>
+			<key>CLANG_ENABLE_OBJC_ARC</key>
+			<string>YES</string>
 		</dict>
 		<key>SDK</key>
 		<string>iphoneos</string>


### PR DESCRIPTION
These are just some small modifications to the iOSOpenDev base template. They:
- add an option to fill in the company/organization name so the standard `__MyCompanyName__` can be avoided
- enable ARC by default in new projects. Other than the added convenience, this also fixes some memory leaks introduced in e8d6141f2b504bd6663beaecc9d00ce5f01ac4c1, e.g. in the NC widget template.

(@kokoabim: I'm assuming that the code I'm talking about expects ARC to always be enabled, but for some reason it just wasn't before. With ARC on, everything's fine. :wink:)
